### PR TITLE
Type Chart Fix

### DIFF
--- a/src/app/pages/envirotrack/report/type-chart/type-chart.component.ts
+++ b/src/app/pages/envirotrack/report/type-chart/type-chart.component.ts
@@ -237,6 +237,7 @@ export class TypeChartComponent implements OnInit {
     this.dataArray = []
 
     if (selectedCompanyId) {
+
       this.track.getFuelData(selectedCompanyId).subscribe({
         next: (res:any) => {
           if (res?.data?.fuel_data) {
@@ -316,6 +317,7 @@ export class TypeChartComponent implements OnInit {
           }
 
         },
+        complete: () => this.getFuelData(id)
       }
     )
   }


### PR DESCRIPTION
Issue occasionally happens when Non-HHD loads faster than HHD. The chart will sometimes include electricity and sometimes omit it.

This update should fix this bug.