### PR TITLE
Adjust API query to fetch all companies

### DIFF
--- a/src/app/pages/envirotrack/envirotrack.service.ts
+++ b/src/app/pages/envirotrack/envirotrack.service.ts
@@ -21,7 +21,7 @@ export class EnvirotrackService {
   updateSelectedCompany = (company: number) => this.selectedCompany.next(company)
 
   getCompanies = () => {
-      return this.http.get(`${this.url}/items/companies`)
+      return this.http.get(`${this.url}/items/companies?limit=-1`)
   }
 
   getCompanyDetails(id: any, fields: string[]) {


### PR DESCRIPTION
Modified the `getCompanies` method to include a query parameter `limit=-1`. This change ensures that the API request retrieves all company records without any limits.