### PR TITLE
improving-interceptor-refresh

### DIFF
--- a/src/app/_helpers/http-interceptor.service.ts
+++ b/src/app/_helpers/http-interceptor.service.ts
@@ -5,12 +5,14 @@ import {
   HttpInterceptorFn,
   HttpRequest,
 } from "@angular/common/http";
-import {catchError, from, switchMap, throwError} from "rxjs";
+import {catchError, from, Observable, switchMap, throwError} from "rxjs";
 import {StorageService} from "../_services/storage.service";
 import {inject} from '@angular/core';
 import {Router} from "@angular/router";
 import {MessageService} from "primeng/api";
 import {AuthService} from "../_services/users/auth.service";
+
+let refreshTokenPromise: Promise<string> | null = null;
 
 
 export const HttpInterceptorService: HttpInterceptorFn = (
@@ -21,73 +23,74 @@ export const HttpInterceptorService: HttpInterceptorFn = (
   const storage = inject(StorageService)
   const router = inject(Router)
   const msg = inject(MessageService)
-  const token = storage.get('access_token');
 
+
+
+  // If refresh is happening just continue on
+  if (req.url.includes('refresh')) {
+    return next(req);
+  }
+
+  // Helper function to add the bearer token to the request
   const addTokenHeader = (request: HttpRequest<any>, token: string | null) => {
     return request.clone({
       headers: request.headers.set('Authorization', 'Bearer ' + token!),
     });
   }
 
-  if (token){
-    const authRequest = addTokenHeader(req, token)
+  const handleLogout = () => {
+    storage.clearAll();
+    refreshTokenPromise = null;
+    router.navigate(['login']);
+    msg.add({
+      severity: 'info',
+      summary: 'Session Expired',
+      detail: 'Please login again to continue.'
+    });
+  };
 
+  const handleRequest = (token: string | null): Observable<any> => {
+    const authRequest = token ? addTokenHeader(req, token) : req;
+
+    // If the token is not refreshing, start the refresh
     return next(authRequest).pipe(
       catchError((error: HttpErrorResponse) => {
-        if ([401, 403].includes(error.status)) {
-          if (error.status === 401) {
-            console.log('401 - getting refresh token')
-            return from(auth.refreshToken()).pipe(
-              switchMap((token: any) => {
-                const newRequest = addTokenHeader(req, token)
-                console.log('New token request', newRequest)
-                window.location.reload()
-                console.log('NEXT REQUEST')
-                return next(newRequest)
-              })
-            )
-          } else if (error.status === 403) {
-            localStorage.clear()
-            router.navigate(['login'])
-          } else {
-            router.navigate(['login'])
+        if (error.status === 401) {
+          if (!refreshTokenPromise) {
+            refreshTokenPromise = auth.refreshToken().then((newToken) => {
+              refreshTokenPromise = null;
+              return newToken;
+            }).catch((err) => {
+              refreshTokenPromise = null;
+              handleLogout();
+              throw err;
+            })
           }
-        }
-        msg.add({
-          severity: 'warning',
-          detail: 'You are unauthorized.'
-        })
-        return throwError(() => error);
-      }))
-  } else {
-    // If the user has no token (not logged in)
-    return next(req).pipe(
-      catchError((error: HttpErrorResponse) => {
-        // console.log('ERROR 2: ', error)
-        if ([401, 403].includes(error.status)) {
-          // auto logout if 401 or 403 response returned from api
-          if (error.status === 401) {
-            console.log('401 Error')
-            // handle 401
 
-          } else if (error.status === 403) {
-            console.log('403 Error')
-            // handle 403
-            localStorage.clear()
-            router.navigate([''])
-          } else {
-            localStorage.clear()
-            router.navigate(['login'])
-          }
-          router.navigate(['login'])
+          // Once refresh is received, retry the original request
+          return from(refreshTokenPromise).pipe(
+            switchMap(newToken => {
+              const newRequest = addTokenHeader(req, newToken);
+              return next(newRequest);
+            }),
+            catchError(refreshError => {
+              console.error('Token refresh failed: ' , refreshError);
+              handleLogout();
+              return throwError(() => refreshError)
+            })
+          )
         }
-        msg.add({
-          severity: 'warning',
-          detail: 'You are unauthorized.'
-        })
-
+        if (error.status === 403) {
+          handleLogout();
+          return throwError(() => error);
+        }
 
         return throwError(() => error);
-      }))
+      })
+    )
   }
+
+  const token = storage.get('access_token');
+  return handleRequest(token)
+
 };

--- a/src/app/_helpers/http-interceptor.service.ts
+++ b/src/app/_helpers/http-interceptor.service.ts
@@ -27,7 +27,7 @@ export const HttpInterceptorService: HttpInterceptorFn = (
 
 
   // If refresh is happening just continue on
-  if (req.url.includes('refresh')) {
+  if (req.url.includes('refresh') ||req.url.includes('login') ) {
     return next(req);
   }
 

--- a/src/app/_helpers/http-interceptor.service.ts
+++ b/src/app/_helpers/http-interceptor.service.ts
@@ -49,7 +49,27 @@ export const HttpInterceptorService: HttpInterceptorFn = (
     });
   };
 
+  const validateTokens = () => {
+    const accessToken = storage.get('access_token');
+    const refreshToken = storage.get('refresh_token');
+
+    if (!accessToken || !refreshToken) {
+      handleLogout()
+      return false;
+    }
+
+    return true;
+
+  }
+
   const handleRequest = (token: string | null): Observable<any> => {
+
+
+    if (!validateTokens()) {
+      return throwError(() => new Error('Unauthorized'))
+    }
+
+
     const authRequest = token ? addTokenHeader(req, token) : req;
 
     // If the token is not refreshing, start the refresh

--- a/src/app/_services/storage.service.ts
+++ b/src/app/_services/storage.service.ts
@@ -52,4 +52,12 @@ export class StorageService {
     return item
   }
 
+  clear = (name: string) => {
+    localStorage.removeItem(name);
+  }
+
+  clearAll = () => {
+    localStorage.clear()
+  }
+
 }

--- a/src/app/pages/digital-twins/dt-report/mergeDuplicateSolutions.ts
+++ b/src/app/pages/digital-twins/dt-report/mergeDuplicateSolutions.ts
@@ -73,7 +73,6 @@ function mergeDuplicateItem(original: any, duplicates: any, type: string) {
   merged.counter = 1;
 
   duplicates.forEach((duplicate: any) => {
-    console.log(duplicate)
     merged.counter = (merged.counter || 1) + 1;
 
     // Handle payback


### PR DESCRIPTION
TODO: Testing

This update is an attempt to improve the interceptor. Currently the interceptor will require a user to refresh their page, or it will try force a reload. This should refresh the token in the background without a refresh necessary.

Due to many requests in the background in fetching companies, company data etc. The refresh request was only attaching to the first GET request. This caused the others to fail and break.

Changes:
- Track whether a refresh token is currently being requested.

```  let refreshTokenPromise: Promise<string> | null = null;```

- Handle cases where a token has failed, a token is currently being requested, a new token has been granted. 

Testing required:
- Refresh token needs to be refreshed after 15 mins. In the network tab this should be handled smoothly without a page refresh.